### PR TITLE
Trigger CSS animation with Javascript

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,4 +1,14 @@
+document.querySelectorAll(".emoji-button").forEach(function (button) {
+  button.addEventListener("webkitAnimationEnd", function() {
+    // reset animation
+    button.style.animationName = "";
+  });
+});
+
 function post_feedback(fb) {
+  var button = document.querySelector(".emoji-button." + fb);
+  button.style.animationName = "pop";
+
   fetch("/feedback/" + fb, {method: "POST"}).catch(console.log);
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -32,11 +32,20 @@ html, body {
 .emoji-button {
   width: 100%;
   height: 100%;
-  transition: all 0.1s ease;
+  animation-duration: 0.4s;
+  animation-timing-function: ease;
 }
 
-.emoji-button:active {
-  transform:scale(1.3);
+@keyframes pop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 #fullscreen {

--- a/templates/index.html.hbs
+++ b/templates/index.html.hbs
@@ -13,16 +13,16 @@
       <h1>{{question}}</h1>
     </div>
     <div class="eq-container">
-      <div class="emoji-button" onClick="post_feedback('very_positive');">
+      <div class="emoji-button very_positive" onClick="post_feedback('very_positive');">
         <img src="public/assets/face-heart.svg" alt="Very positive">
       </div>
-      <div class="emoji-button" onClick="post_feedback('positive');">
+      <div class="emoji-button positive" onClick="post_feedback('positive');">
         <img src="public/assets/face-smiling.svg" alt="Positive">
       </div>
-      <div class="emoji-button" onClick="post_feedback('negative');">
+      <div class="emoji-button negative" onClick="post_feedback('negative');">
         <img src="public/assets/face-frowning.svg" alt="Negative">
       </div>
-      <div class="emoji-button" onClick="post_feedback('very_negative');">
+      <div class="emoji-button very_negative" onClick="post_feedback('very_negative');">
         <img src="public/assets/face-crying.svg" alt="Very negative">
       </div>
     </div>


### PR DESCRIPTION
Using transform with :active stops the animation
for short mouse clicks. Instead, triggering a CSS
`@keyframes` animation with Javascript always shows
the whole animation.

You can test this by trying to:
- Push, hold and release the left mouse button
- just click the left mouse button (without holding)

You should see a huge difference without this patch. But with this patch, the animation will always trigger once the mouse button is released and will not stop half-way. On the tablet this is even harder to test but it happened there, too.